### PR TITLE
Bug Fix. Only multiple if the gradient input is available

### DIFF
--- a/excitationbp/functions/eb_linear.py
+++ b/excitationbp/functions/eb_linear.py
@@ -25,11 +25,11 @@ class EBLinear(Function):
         # print("this is a {} linear layer ({})"
         #       .format('pos' if torch.use_pos_weights else 'neg', grad_output.sum().data[0]))
         weight = weight.clamp(min=0) if torch.use_pos_weights else weight.clamp(max=0).abs()
-        
+
         input.data = input.data - input.data.min() if input.data.min() < 0 else input.data
         grad_output /= input.mm(weight.t()).abs() + 1e-10 # normalize
         ### stop EB-SPECIFIC CODE  ###
-    
+
         grad_input = grad_weight = grad_bias = None
 
         # These needs_input_grad checks are optional and there only to
@@ -38,13 +38,14 @@ class EBLinear(Function):
         # not an error.
         if ctx.needs_input_grad[0]:
             grad_input = grad_output.mm(weight)
+            ### start EB-SPECIFIC CODE  ###
+            grad_input *= input
+            ### stop EB-SPECIFIC CODE  ###
+
         if ctx.needs_input_grad[1]:
             grad_weight = grad_output.t().mm(input)
         if bias is not None and ctx.needs_input_grad[2]:
             grad_bias = grad_output.sum(0).squeeze(0)
 
-        ### start EB-SPECIFIC CODE  ###
-        grad_input *= input
-        ### stop EB-SPECIFIC CODE  ###
-        
+
         return grad_input, grad_weight, grad_bias


### PR DESCRIPTION
Multiplying gradient input even when it is None.

This line cause the issue:
`grad_input *= input`
